### PR TITLE
distinct user count

### DIFF
--- a/labstats/bin/init.py
+++ b/labstats/bin/init.py
@@ -61,9 +61,6 @@ CREATE VIEW `staff_in_lab_public` AS
     SELECT `user`, `host`, `start` FROM `users_in_lab` WHERE `user` IN (
         SELECT `user` FROM `staff`
     );
-    
-CREATE VIEW `staff_in_lab_count_public` AS
-    SELECT COUNT(DISTINCT `user`) AS `count` FROM `staff_in_lab_public`; 
 
 CREATE VIEW `printer_pages_public` AS
     SELECT `id`, `date`, `printer`, `value` FROM `printer_pages`;
@@ -83,7 +80,6 @@ CREATE VIEW `daily_sessions_public` AS
 GRANT SELECT ON `ocfstats`.`session_duration_public` TO 'anonymous'@'%';
 GRANT SELECT ON `ocfstats`.`users_in_lab_count_public` TO 'anonymous'@'%';
 GRANT SELECT ON `ocfstats`.`staff_in_lab_public` TO 'anonymous'@'%';
-GRANT SELECT ON `ocfstats`.`staff_in_lab_count_public` TO 'anonymous'@'%';
 GRANT SELECT ON `ocfstats`.`staff_session_duration_public` TO 'anonymous'@'%';
 GRANT SELECT ON `ocfstats`.`printer_pages_public` TO 'anonymous'@'%';
 GRANT SELECT ON `ocfstats`.`printer_toner_public` TO 'anonymous'@'%';

--- a/labstats/bin/init.py
+++ b/labstats/bin/init.py
@@ -55,12 +55,15 @@ CREATE VIEW `users_in_lab` AS
     SELECT `user`, `host`, `start` FROM `session` WHERE `end` IS NULL;
 
 CREATE VIEW `users_in_lab_count_public` AS
-    SELECT count(*) as `count` FROM `users_in_lab`;
+    SELECT COUNT(DISTINCT `user`) AS `count` FROM `users_in_lab`;
 
 CREATE VIEW `staff_in_lab_public` AS
     SELECT `user`, `host`, `start` FROM `users_in_lab` WHERE `user` IN (
         SELECT `user` FROM `staff`
     );
+    
+CREATE VIEW `staff_in_lab_count_public` AS
+    SELECT COUNT(DISTINCT `user`) AS `count` FROM `staff_in_lab_public`; 
 
 CREATE VIEW `printer_pages_public` AS
     SELECT `id`, `date`, `printer`, `value` FROM `printer_pages`;

--- a/labstats/bin/init.py
+++ b/labstats/bin/init.py
@@ -83,6 +83,7 @@ CREATE VIEW `daily_sessions_public` AS
 GRANT SELECT ON `ocfstats`.`session_duration_public` TO 'anonymous'@'%';
 GRANT SELECT ON `ocfstats`.`users_in_lab_count_public` TO 'anonymous'@'%';
 GRANT SELECT ON `ocfstats`.`staff_in_lab_public` TO 'anonymous'@'%';
+GRANT SELECT ON `ocfstats`.`staff_in_lab_count_public` TO 'anonymous'@'%';
 GRANT SELECT ON `ocfstats`.`staff_session_duration_public` TO 'anonymous'@'%';
 GRANT SELECT ON `ocfstats`.`printer_pages_public` TO 'anonymous'@'%';
 GRANT SELECT ON `ocfstats`.`printer_toner_public` TO 'anonymous'@'%';


### PR DESCRIPTION
@jvperrin mentioned that the stats page lists every active session as a unique user, so when logged into three desktops, ocf.io/stats shows "3 users in lab, jvperrin on <x>, jvperrin on <y>, jvperrin on <z>". This would update the view to only return the correct count of unique users/staff in lab while preserving the listing of all active sessions.